### PR TITLE
fix(ui): Match sidebar background to main layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+"node_modules" 

--- a/src/Sidebar/Sidebar.css
+++ b/src/Sidebar/Sidebar.css
@@ -12,7 +12,9 @@
     overflow-y: auto;
     overflow-x: hidden;
     box-sizing: border-box;
-    background: rgba(255, 255, 255, 0.95);
+    background: linear-gradient(180deg, #ffc4a3 0%, #ffab8e 35%, #ff9478 70%, #ff8366 100%) !important;
+    background-image: linear-gradient(180deg, #ffc7a6 0%, #ffcab8 35%, #f08368 70%, #ff8366 100%) !important;
+    box-shadow: 3px 0 15px rgba(255, 140, 100, 0.15);
     transition: transform 0.3s ease;
 }
 


### PR DESCRIPTION
Closes #16

This PR fixes the UI bug where the sidebar's background color did not match the main page.

- Updated the `background` property in `src/Sidebar/Sidebar.css` to use the same `linear-gradient` as the main body.

**Before:**
<img width="1142" height="905" alt="Screenshot 2025-10-24 145507" src="https://github.com/user-attachments/assets/a2728393-c5b0-439d-9f7b-483b1a024b22" />

--

**After:**
<img width="1131" height="907" alt="Screenshot 2025-10-24 173029" src="https://github.com/user-attachments/assets/d520e500-d419-4f79-990e-4b6a2bd65713" />
